### PR TITLE
[develop] 구글 로그인, 회원가입 구현

### DIFF
--- a/data/src/main/java/com/cheocharm/data/error/ErrorData.kt
+++ b/data/src/main/java/com/cheocharm/data/error/ErrorData.kt
@@ -9,4 +9,6 @@ sealed class ErrorData(
     data class MapZCertNumberUnavailable(override val message: String) : ErrorData(message)
     data class MapZSignUpUnavailable(override val message: String) : ErrorData(message)
     data class MapZSignInUnavailable(override val message: String) : ErrorData(message)
+    data class GoogleSignInUnavailable(override val message: String) : ErrorData(message)
+    data class GoogleSignUpUnavailable(override val message: String) : ErrorData(message)
 }

--- a/data/src/main/java/com/cheocharm/data/error/ErrorMapper.kt
+++ b/data/src/main/java/com/cheocharm/data/error/ErrorMapper.kt
@@ -7,4 +7,6 @@ internal fun ErrorData.toDomain(): Error = when (this) {
     is ErrorData.MapZCertNumberUnavailable -> Error.MapZCertNumberUnavailable(message)
     is ErrorData.MapZSignUpUnavailable -> Error.MapZSignUpUnavailable(message)
     is ErrorData.MapZSignInUnavailable -> Error.MapZSignInUnavailable(message)
+    is ErrorData.GoogleSignInUnavailable -> Error.GoogleSignInUnavailable(message)
+    is ErrorData.GoogleSignUpUnavailable -> Error.GoogleSignUpUnavailable(message)
 }

--- a/data/src/main/java/com/cheocharm/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/cheocharm/data/repository/AuthRepositoryImpl.kt
@@ -39,4 +39,12 @@ class AuthRepositoryImpl @Inject constructor(
     override fun removeIsAutoSignIn() {
         authLocalDataSource.removeIsAutoSignIn()
     }
+
+    override fun saveSignInType(signInType: String) {
+        authLocalDataSource.saveSignInType(signInType)
+    }
+
+    override fun removeSignInType() {
+        authLocalDataSource.removeSignInType()
+    }
 }

--- a/data/src/main/java/com/cheocharm/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/cheocharm/data/repository/LoginRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.cheocharm.data.repository
 import com.cheocharm.data.error.ErrorData
 import com.cheocharm.data.error.toDomain
 import com.cheocharm.data.source.LoginRemoteDataSource
+import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSign
 import com.cheocharm.domain.model.MapZSignInRequest
 import com.cheocharm.domain.model.MapZSignUpRequest
@@ -33,6 +34,26 @@ class LoginRepositoryImpl @Inject constructor(
 
     override suspend fun requestMapZSignIn(mapZSignInRequest: MapZSignInRequest): Result<MapZSign> {
         val result = loginRemoteDataSource.requestMapZSignIn(mapZSignInRequest)
+
+        return when (val exception = result.exceptionOrNull()) {
+            is ErrorData -> Result.failure(exception.toDomain())
+            null -> result
+            else -> Result.failure(exception)
+        }
+    }
+
+    override suspend fun requestGoogleSignIn(idToken: String): Result<MapZSign> {
+        val result = loginRemoteDataSource.requestGoogleSignIn(idToken)
+
+        return when (val exception = result.exceptionOrNull()) {
+            is ErrorData -> Result.failure(exception.toDomain())
+            null -> result
+            else -> Result.failure(exception)
+        }
+    }
+
+    override suspend fun requestGoogleSignUp(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign> {
+        val result = loginRemoteDataSource.requestGoogleSignUp(googleSignUpRequest)
 
         return when (val exception = result.exceptionOrNull()) {
             is ErrorData -> Result.failure(exception.toDomain())

--- a/data/src/main/java/com/cheocharm/data/source/AuthLocalDataSource.kt
+++ b/data/src/main/java/com/cheocharm/data/source/AuthLocalDataSource.kt
@@ -17,4 +17,8 @@ interface AuthLocalDataSource {
     fun removeRefreshToken()
 
     fun removeIsAutoSignIn()
+
+    fun saveSignInType(signInType: String)
+
+    fun removeSignInType()
 }

--- a/data/src/main/java/com/cheocharm/data/source/LoginRemoteDataSource.kt
+++ b/data/src/main/java/com/cheocharm/data/source/LoginRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.cheocharm.data.source
 
+import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSign
 import com.cheocharm.domain.model.MapZSignInRequest
 import com.cheocharm.domain.model.MapZSignUpRequest
@@ -11,4 +12,8 @@ interface LoginRemoteDataSource {
     suspend fun requestMapZSignUp(mapZSignUpRequest: MapZSignUpRequest): Result<MapZSign>
 
     suspend fun requestMapZSignIn(mapZSignInRequest: MapZSignInRequest): Result<MapZSign>
+
+    suspend fun requestGoogleSignIn(idToken: String): Result<MapZSign>
+
+    suspend fun requestGoogleSignUp(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign>
 }

--- a/domain/src/main/java/com/cheocharm/domain/model/Error.kt
+++ b/domain/src/main/java/com/cheocharm/domain/model/Error.kt
@@ -9,4 +9,6 @@ sealed class Error(
     data class MapZCertNumberUnavailable(override val message: String) : Error()
     data class MapZSignUpUnavailable(override val message: String) : Error()
     data class MapZSignInUnavailable(override val message: String) : Error()
+    data class GoogleSignInUnavailable(override val message: String) : Error()
+    data class GoogleSignUpUnavailable(override val message: String) : Error()
 }

--- a/domain/src/main/java/com/cheocharm/domain/model/GoogleSignUpRequest.kt
+++ b/domain/src/main/java/com/cheocharm/domain/model/GoogleSignUpRequest.kt
@@ -1,7 +1,10 @@
 package com.cheocharm.domain.model
 
+import java.io.File
+
 data class GoogleSignUpRequest(
     val username: String,
     val idToken: String,
-    val pushAgreement: Boolean
+    val pushAgreement: Boolean,
+    val userImage: File
 )

--- a/domain/src/main/java/com/cheocharm/domain/model/GoogleSignUpRequest.kt
+++ b/domain/src/main/java/com/cheocharm/domain/model/GoogleSignUpRequest.kt
@@ -1,0 +1,7 @@
+package com.cheocharm.domain.model
+
+data class GoogleSignUpRequest(
+    val username: String,
+    val idToken: String,
+    val pushAgreement: Boolean
+)

--- a/domain/src/main/java/com/cheocharm/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/cheocharm/domain/repository/AuthRepository.kt
@@ -17,4 +17,8 @@ interface AuthRepository {
     fun removeRefreshToken()
 
     fun removeIsAutoSignIn()
+
+    fun saveSignInType(signInType: String)
+
+    fun removeSignInType()
 }

--- a/domain/src/main/java/com/cheocharm/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/cheocharm/domain/repository/LoginRepository.kt
@@ -1,5 +1,6 @@
 package com.cheocharm.domain.repository
 
+import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSignInRequest
 import com.cheocharm.domain.model.MapZSign
 import com.cheocharm.domain.model.MapZSignUpRequest
@@ -11,4 +12,8 @@ interface LoginRepository {
     suspend fun requestMapZSignUp(mapZSignUpRequest: MapZSignUpRequest): Result<MapZSign>
 
     suspend fun requestMapZSignIn(mapZSignInRequest: MapZSignInRequest): Result<MapZSign>
+
+    suspend fun requestGoogleSignIn(idToken: String): Result<MapZSign>
+
+    suspend fun requestGoogleSignUp(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign>
 }

--- a/domain/src/main/java/com/cheocharm/domain/usecase/RequestGoogleSignInUseCase.kt
+++ b/domain/src/main/java/com/cheocharm/domain/usecase/RequestGoogleSignInUseCase.kt
@@ -1,0 +1,14 @@
+package com.cheocharm.domain.usecase
+
+import com.cheocharm.domain.model.MapZSign
+import com.cheocharm.domain.repository.LoginRepository
+import javax.inject.Inject
+
+class RequestGoogleSignInUseCase @Inject constructor(
+    private val loginRepository: LoginRepository
+) {
+
+    suspend operator fun invoke(idToken: String): Result<MapZSign> {
+        return loginRepository.requestGoogleSignIn(idToken)
+    }
+}

--- a/domain/src/main/java/com/cheocharm/domain/usecase/RequestGoogleSignUpUseCase.kt
+++ b/domain/src/main/java/com/cheocharm/domain/usecase/RequestGoogleSignUpUseCase.kt
@@ -1,0 +1,14 @@
+package com.cheocharm.domain.usecase
+
+import com.cheocharm.domain.model.GoogleSignUpRequest
+import com.cheocharm.domain.model.MapZSign
+import com.cheocharm.domain.repository.LoginRepository
+import javax.inject.Inject
+
+class RequestGoogleSignUpUseCase @Inject constructor(
+    private val loginRepository: LoginRepository
+) {
+
+    suspend operator fun invoke(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign> =
+        loginRepository.requestGoogleSignUp(googleSignUpRequest)
+}

--- a/domain/src/main/java/com/cheocharm/domain/usecase/RequestSignOutUseCase.kt
+++ b/domain/src/main/java/com/cheocharm/domain/usecase/RequestSignOutUseCase.kt
@@ -11,5 +11,6 @@ class RequestSignOutUseCase @Inject constructor(
         authRepository.removeAccessToken()
         authRepository.removeRefreshToken()
         authRepository.removeIsAutoSignIn()
+        authRepository.removeSignInType()
     }
 }

--- a/domain/src/main/java/com/cheocharm/domain/usecase/SaveSignInTypeUseCase.kt
+++ b/domain/src/main/java/com/cheocharm/domain/usecase/SaveSignInTypeUseCase.kt
@@ -1,0 +1,13 @@
+package com.cheocharm.domain.usecase
+
+import com.cheocharm.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class SaveSignInTypeUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+
+    operator fun invoke(signInType: String) {
+        authRepository.saveSignInType(signInType)
+    }
+}

--- a/local/src/main/java/com/cheocharm/local/source/AuthLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/cheocharm/local/source/AuthLocalDataSourceImpl.kt
@@ -42,9 +42,18 @@ class AuthLocalDataSourceImpl @Inject constructor(
         sharedPrefManager.remove(IS_AUTO_SIGN_IN)
     }
 
+    override fun saveSignInType(signInType: String) {
+        sharedPrefManager.setString(SIGN_IN_TYPE, signInType)
+    }
+
+    override fun removeSignInType() {
+        sharedPrefManager.remove(SIGN_IN_TYPE)
+    }
+
     companion object {
         private const val ACCESS_TOKEN = "accessToken"
         private const val REFRESH_TOKEN = "refreshToken"
         private const val IS_AUTO_SIGN_IN = "isAutoSignIn"
+        private const val SIGN_IN_TYPE = "signInType"
     }
 }

--- a/presentation/src/main/java/com/cheocharm/presentation/common/Constants.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/common/Constants.kt
@@ -1,0 +1,4 @@
+package com.cheocharm.presentation.common
+
+const val SIGN_UP_TYPE = "signUpType"
+const val GOOGLE_ID_TOKEN = "googleIdToken"

--- a/presentation/src/main/java/com/cheocharm/presentation/model/SignType.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/model/SignType.kt
@@ -1,0 +1,5 @@
+package com.cheocharm.presentation.model
+
+enum class SignType(val str: String) {
+    MAPZ("MapZ"), GOOGLE("Google")
+}

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignInFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignInFragment.kt
@@ -120,9 +120,13 @@ class SignInFragment : BaseFragment<FragmentSignInBinding>(R.layout.fragment_sig
             Toast.makeText(requireActivity(), it, Toast.LENGTH_SHORT).show()
         }
         signInViewModel.goToMain.observe(viewLifecycleOwner, EventObserver {
-            val intent = Intent(requireActivity(), MainActivity::class.java)
-            startActivity(intent)
-            requireActivity().finish()
+            if (it) {
+                val intent = Intent(requireActivity(), MainActivity::class.java)
+                startActivity(intent)
+                requireActivity().finish()
+            } else {
+                googleSignInClient.signOut()
+            }
         })
         signInViewModel.goToGoogleSignUpWithIdToken.observe(
             viewLifecycleOwner,

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignInViewModel.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignInViewModel.kt
@@ -41,8 +41,8 @@ class SignInViewModel @Inject constructor(
     val isSignInEnabled: LiveData<Boolean>
         get() = _isSignInEnabled
 
-    private val _goToMain = MutableLiveData<Event<Unit>>()
-    val goToMain: LiveData<Event<Unit>>
+    private val _goToMain = MutableLiveData<Event<Boolean>>()
+    val goToMain: LiveData<Event<Boolean>>
         get() = _goToMain
 
     private val _goToGoogleSignUpWithIdToken = MutableLiveData<Event<String>>()
@@ -82,7 +82,7 @@ class SignInViewModel @Inject constructor(
                     )
                     saveAutoSignInUseCase.invoke(isAutoSignIn)
                     saveSignInTypeUseCase.invoke(SignType.MAPZ.str)
-                    _goToMain.value = Event(Unit)
+                    _goToMain.value = Event(true)
                 }
                 .onFailure {
                     when (it) {
@@ -95,9 +95,12 @@ class SignInViewModel @Inject constructor(
 
     fun checkAutoSignIn() {
         val signInCheck = checkAutoSignInUseCase.invoke()
-        if (signInCheck.accessToken.isNullOrEmpty() || signInCheck.refreshToken.isNullOrEmpty()) return
+        if (signInCheck.accessToken.isNullOrEmpty() || signInCheck.refreshToken.isNullOrEmpty()) {
+            _goToMain.value = Event(false)
+            return
+        }
 
-        if (signInCheck.isAutoSignIn) _goToMain.value = Event(Unit)
+        if (signInCheck.isAutoSignIn) _goToMain.value = Event(true)
     }
 
     fun handleSignInResult(completedTask: Task<GoogleSignInAccount>) {
@@ -116,7 +119,7 @@ class SignInViewModel @Inject constructor(
                                 )
                                 saveAutoSignInUseCase.invoke(isAutoSignIn)
                                 saveSignInTypeUseCase.invoke(SignType.GOOGLE.str)
-                                _goToMain.value = Event(Unit)
+                                _goToMain.value = Event(true)
                             }
                         }
                         .onFailure { throwable ->

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
@@ -7,6 +7,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.cheocharm.base.BaseFragment
 import com.cheocharm.presentation.R
+import com.cheocharm.presentation.common.GOOGLE_ID_TOKEN
+import com.cheocharm.presentation.common.SIGN_UP_TYPE
 import com.cheocharm.presentation.databinding.FragmentSignUpAgreeBinding
 import com.cheocharm.presentation.model.SignType
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +21,11 @@ class SignUpAgreeFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val signUpType: SignType = (arguments?.get(SIGN_UP_TYPE) ?: SignType.MAPZ) as SignType
+        val googleIdToken: String? = arguments?.get(GOOGLE_ID_TOKEN) as String?
+        signViewModel.setSignUpType(signUpType)
+        signViewModel.setGoogleIdToken(googleIdToken ?: return)
 
         initView()
         initButton()

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
@@ -1,6 +1,5 @@
 package com.cheocharm.presentation.ui.login
 
-import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -9,6 +8,7 @@ import androidx.navigation.fragment.findNavController
 import com.cheocharm.base.BaseFragment
 import com.cheocharm.presentation.R
 import com.cheocharm.presentation.databinding.FragmentSignUpAgreeBinding
+import com.cheocharm.presentation.model.SignType
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -30,7 +30,10 @@ class SignUpAgreeFragment :
             findNavController().popBackStack()
         }
         binding.btnSignUpAgreeNext.setOnClickListener {
-            findNavController().navigate(R.id.action_signUpAgreeFragment_to_signUpFragment)
+            when (signViewModel.signUpType) {
+                SignType.MAPZ -> findNavController().navigate(R.id.action_signUpAgreeFragment_to_signUpFragment)
+                SignType.GOOGLE -> findNavController().navigate(R.id.action_signUpAgreeFragment_to_signUpProfileFragment)
+            }
         }
         binding.containerSignUpAgreeItem1.btnSignUpAgree.setOnClickListener {
             signViewModel.onAgreementItem1Clicked()

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
@@ -26,7 +26,7 @@ class SignUpAgreeFragment :
         val googleIdToken: String? = arguments?.get(GOOGLE_ID_TOKEN) as String?
         signViewModel.setSignUpType(signUpType)
         googleIdToken?.let {
-            signViewModel.setGoogleIdToken(googleIdToken)
+            signViewModel.setGoogleIdToken(it)
         }
 
         initView()

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpAgreeFragment.kt
@@ -25,7 +25,9 @@ class SignUpAgreeFragment :
         val signUpType: SignType = (arguments?.get(SIGN_UP_TYPE) ?: SignType.MAPZ) as SignType
         val googleIdToken: String? = arguments?.get(GOOGLE_ID_TOKEN) as String?
         signViewModel.setSignUpType(signUpType)
-        signViewModel.setGoogleIdToken(googleIdToken ?: return)
+        googleIdToken?.let {
+            signViewModel.setGoogleIdToken(googleIdToken)
+        }
 
         initView()
         initButton()

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpProfileFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignUpProfileFragment.kt
@@ -56,7 +56,7 @@ class SignUpProfileFragment :
             signViewModel.checkProfileEnabled()
         }
         binding.btnSignUpProfileComplete.setOnClickListener {
-            signViewModel.requestMapZSignUp()
+            signViewModel.requestSignUp()
         }
     }
 

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignViewModel.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignViewModel.kt
@@ -1,7 +1,10 @@
 package com.cheocharm.presentation.ui.login
 
 import android.util.Patterns
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.cheocharm.domain.model.Error
 import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSignUpRequest
@@ -9,8 +12,6 @@ import com.cheocharm.domain.usecase.RequestCertNumberUseCase
 import com.cheocharm.domain.usecase.RequestGoogleSignUpUseCase
 import com.cheocharm.domain.usecase.RequestMapZSignUpUseCase
 import com.cheocharm.presentation.common.Event
-import com.cheocharm.presentation.common.GOOGLE_ID_TOKEN
-import com.cheocharm.presentation.common.SIGN_UP_TYPE
 import com.cheocharm.presentation.model.SignType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -281,9 +282,10 @@ class SignViewModel @Inject constructor(
         val nickname = nickname.value ?: return
         val idToken = googleIdToken ?: return
         val pushAgreement = agreementItem3.value ?: return
+        val image = profileImage.value ?: return
 
         viewModelScope.launch {
-            requestGoogleSignUpUseCase.invoke(GoogleSignUpRequest(nickname, idToken, pushAgreement))
+            requestGoogleSignUpUseCase.invoke(GoogleSignUpRequest(nickname, idToken, pushAgreement, image))
                 .onSuccess {
                     setProfileToastMessage("구글 회원가입을 완료하였습니다.")
                     _goToSignIn.value = Event(Unit)

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignViewModel.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/login/SignViewModel.kt
@@ -20,17 +20,15 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle,
     private val requestCertNumberUseCase: RequestCertNumberUseCase,
     private val requestMapZSignUpUseCase: RequestMapZSignUpUseCase,
     private val requestGoogleSignUpUseCase: RequestGoogleSignUpUseCase
 ) : ViewModel() {
 
-    var signUpType: SignType
+    lateinit var signUpType: SignType
         private set
 
-    var googleIdToken: String? = null
-        private set
+    private var googleIdToken: String? = null
 
     // Agreement
     private val _agreementItem1 = MutableLiveData(false)
@@ -121,9 +119,12 @@ class SignViewModel @Inject constructor(
     val profileToastMessage: LiveData<String>
         get() = _profileToastMessage
 
-    init {
-        signUpType = savedStateHandle[SIGN_UP_TYPE] ?: SignType.MAPZ
-        googleIdToken = savedStateHandle[GOOGLE_ID_TOKEN]
+    fun setSignUpType(signUpType: SignType) {
+        this.signUpType = signUpType
+    }
+
+    fun setGoogleIdToken(idToken: String) {
+        googleIdToken = idToken
     }
 
     // Agreement

--- a/presentation/src/main/java/com/cheocharm/presentation/ui/mypage/MyPageFragment.kt
+++ b/presentation/src/main/java/com/cheocharm/presentation/ui/mypage/MyPageFragment.kt
@@ -5,14 +5,31 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import com.cheocharm.base.BaseFragment
+import com.cheocharm.presentation.BuildConfig
 import com.cheocharm.presentation.R
 import com.cheocharm.presentation.databinding.FragmentMyPageBinding
 import com.cheocharm.presentation.ui.login.SignActivity
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_page) {
     private val myPageViewModel: MyPageViewModel by viewModels()
+
+    private lateinit var googleSignInClient: GoogleSignInClient
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(BuildConfig.GOOGLE_LOGIN_WEB_CLIENT_ID)
+            .requestEmail()
+            .build()
+
+        googleSignInClient = GoogleSignIn.getClient(requireActivity(), gso)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -25,6 +42,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(R.layout.fragment_my_
 
     private fun initButton() {
         binding.btnMyPageSignOut.setOnClickListener {
+            googleSignInClient.signOut()
             myPageViewModel.requestSignOut()
             val intent = Intent(requireActivity(), SignActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/remote/src/main/java/com/cheocharm/remote/api/LoginApi.kt
+++ b/remote/src/main/java/com/cheocharm/remote/api/LoginApi.kt
@@ -1,19 +1,19 @@
 package com.cheocharm.remote.api
 
 import com.cheocharm.remote.model.BaseResponse
-import com.cheocharm.remote.model.GoogleSignInResponse
-import com.cheocharm.remote.model.GoogleSignUpResponse
 import com.cheocharm.remote.model.MapZSignResponse
+import com.cheocharm.remote.model.request.GoogleSignUpDto
 import com.cheocharm.remote.model.request.MapZSignInDto
 import com.cheocharm.remote.model.request.MapZSignUpDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import org.json.JSONObject
 import retrofit2.http.*
 
 interface LoginApi {
 
     @POST("users")
-    suspend fun signUpGoogleLogin(@Body body: RequestBody): BaseResponse<GoogleSignUpResponse>
+    suspend fun signUpGoogleLogin(@Body body: GoogleSignUpDto): BaseResponse<MapZSignResponse>
 
     @Multipart
     @POST("users/signup")
@@ -26,7 +26,7 @@ interface LoginApi {
     suspend fun signInMapZ(@Body body: MapZSignInDto): BaseResponse<MapZSignResponse>
 
     @POST("users/login")
-    suspend fun signInGoogleLogin(@Body body: RequestBody): BaseResponse<GoogleSignInResponse>
+    suspend fun signInGoogleLogin(@Body body: HashMap<String, String>): BaseResponse<MapZSignResponse>
 
     @POST("users/email")
     suspend fun requestEmailCertNumber(@Body body: RequestBody): BaseResponse<String>

--- a/remote/src/main/java/com/cheocharm/remote/api/LoginApi.kt
+++ b/remote/src/main/java/com/cheocharm/remote/api/LoginApi.kt
@@ -7,13 +7,19 @@ import com.cheocharm.remote.model.request.MapZSignInDto
 import com.cheocharm.remote.model.request.MapZSignUpDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import org.json.JSONObject
-import retrofit2.http.*
+import retrofit2.http.Body
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
 
 interface LoginApi {
 
+    @Multipart
     @POST("users")
-    suspend fun signUpGoogleLogin(@Body body: GoogleSignUpDto): BaseResponse<MapZSignResponse>
+    suspend fun signUpGoogleLogin(
+        @Part("dto") dto: GoogleSignUpDto,
+        @Part file: MultipartBody.Part
+    ): BaseResponse<MapZSignResponse>
 
     @Multipart
     @POST("users/signup")

--- a/remote/src/main/java/com/cheocharm/remote/mapper/SignMapper.kt
+++ b/remote/src/main/java/com/cheocharm/remote/mapper/SignMapper.kt
@@ -1,9 +1,11 @@
 package com.cheocharm.remote.mapper
 
+import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSign
 import com.cheocharm.domain.model.MapZSignInRequest
 import com.cheocharm.domain.model.MapZSignUpRequest
 import com.cheocharm.remote.model.MapZSignResponse
+import com.cheocharm.remote.model.request.GoogleSignUpDto
 import com.cheocharm.remote.model.request.MapZSignInDto
 import com.cheocharm.remote.model.request.MapZSignUpDto
 
@@ -19,5 +21,10 @@ internal fun MapZSignResponse.toDomain(): MapZSign {
 
 // domain -> remote
 internal fun MapZSignInRequest.toDto(): MapZSignInDto {
-    return MapZSignInDto(this.email, this.pwd)
+    return MapZSignInDto(email, pwd)
+}
+
+// domain -> remote
+internal fun GoogleSignUpRequest.toDto(): GoogleSignUpDto {
+    return GoogleSignUpDto(username, idToken, pushAgreement)
 }

--- a/remote/src/main/java/com/cheocharm/remote/model/GoogleSignInResponse.kt
+++ b/remote/src/main/java/com/cheocharm/remote/model/GoogleSignInResponse.kt
@@ -1,5 +1,0 @@
-package com.cheocharm.remote.model
-
-data class GoogleSignInResponse(
-    val idToken: String
-)

--- a/remote/src/main/java/com/cheocharm/remote/model/GoogleSignUpResponse.kt
+++ b/remote/src/main/java/com/cheocharm/remote/model/GoogleSignUpResponse.kt
@@ -1,6 +1,0 @@
-package com.cheocharm.remote.model
-
-data class GoogleSignUpResponse(
-    val username: String,
-    val idToken: String
-)

--- a/remote/src/main/java/com/cheocharm/remote/model/request/GoogleSignUpDto.kt
+++ b/remote/src/main/java/com/cheocharm/remote/model/request/GoogleSignUpDto.kt
@@ -1,0 +1,7 @@
+package com.cheocharm.remote.model.request
+
+data class GoogleSignUpDto(
+    val username: String,
+    val idToken: String,
+    val pushAgreement: Boolean
+)

--- a/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
@@ -81,7 +81,7 @@ class LoginRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun requestGoogleSignIn(idToken: String): Result<MapZSign> {
         val result = runCatching { loginApi.signInGoogleLogin(hashMapOf("idToken" to idToken)) }
-        println(result)
+
         return when (val exception = result.exceptionOrNull()) {
             null -> {
                 val response =

--- a/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
@@ -64,7 +64,7 @@ class LoginRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun requestMapZSignIn(mapZSignInRequest: MapZSignInRequest): Result<MapZSign> {
         val result = runCatching { loginApi.signInMapZ(mapZSignInRequest.toDto()) }
-        println(result)
+
         return when (val exception = result.exceptionOrNull()) {
             null -> {
                 val response =

--- a/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.cheocharm.remote.source
 
 import com.cheocharm.data.error.ErrorData
 import com.cheocharm.data.source.LoginRemoteDataSource
+import com.cheocharm.domain.model.GoogleSignUpRequest
 import com.cheocharm.domain.model.MapZSign
 import com.cheocharm.domain.model.MapZSignInRequest
 import com.cheocharm.domain.model.MapZSignUpRequest
@@ -71,6 +72,39 @@ class LoginRemoteDataSourceImpl @Inject constructor(
                 Result.success(
                     response.data?.toDomain()
                         ?: return Result.failure(ErrorData.MapZSignInUnavailable(response.message))
+                )
+            }
+            is UnknownHostException -> Result.failure(ErrorData.NetworkUnavailable)
+            else -> Result.failure(exception)
+        }
+    }
+
+    override suspend fun requestGoogleSignIn(idToken: String): Result<MapZSign> {
+        val result = runCatching { loginApi.signInGoogleLogin(hashMapOf("idToken" to idToken)) }
+        println(result)
+        return when (val exception = result.exceptionOrNull()) {
+            null -> {
+                val response =
+                    result.getOrNull() ?: return Result.failure(Throwable(NullPointerException()))
+                Result.success(
+                    response.data?.toDomain()
+                        ?: return Result.failure(ErrorData.GoogleSignInUnavailable(response.message))
+                )
+            }
+            is UnknownHostException -> Result.failure(ErrorData.NetworkUnavailable)
+            else -> Result.failure(exception)
+        }
+    }
+
+    override suspend fun requestGoogleSignUp(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign> {
+        val result = runCatching { loginApi.signUpGoogleLogin(googleSignUpRequest.toDto()) }
+        return when (val exception = result.exceptionOrNull()) {
+            null -> {
+                val response =
+                    result.getOrNull() ?: return Result.failure(Throwable(NullPointerException()))
+                Result.success(
+                    response.data?.toDomain()
+                        ?: return Result.failure(ErrorData.GoogleSignUpUnavailable(response.message))
                 )
             }
             is UnknownHostException -> Result.failure(ErrorData.NetworkUnavailable)

--- a/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
+++ b/remote/src/main/java/com/cheocharm/remote/source/LoginRemoteDataSourceImpl.kt
@@ -97,7 +97,14 @@ class LoginRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun requestGoogleSignUp(googleSignUpRequest: GoogleSignUpRequest): Result<MapZSign> {
-        val result = runCatching { loginApi.signUpGoogleLogin(googleSignUpRequest.toDto()) }
+        val fileRequestBody = MultipartBody.Part.createFormData(
+            "file",
+            googleSignUpRequest.userImage.name,
+            googleSignUpRequest.userImage.asRequestBody("image/*".toMediaType())
+        )
+
+        val result =
+            runCatching { loginApi.signUpGoogleLogin(googleSignUpRequest.toDto(), fileRequestBody) }
         return when (val exception = result.exceptionOrNull()) {
             null -> {
                 val response =


### PR DESCRIPTION
# 기능 구현 내용
- [x] 구글 로그인, 회원가입할 때 Error, ErrorData, ErrorMapper 추가
- [x] 구글 로그인, 회원가입 API 수정
- [x] 구글 로그인 먼저 시도 후 회원가입이 안된 경우 회원가입 진행
  - [x] 회원가입할 때 구글, MapZ 회원가입 구분
  - [x] 개인정보동의 화면 -> 프로필 화면으로 이동
- [x] 로그인할 때 로그인 타입도 SharedPreferece에 저장
- [x] 구글 로그아웃 추가
  : 구글 API가 알아서 SharedPreferece에 앱의 로그인 관련 내용을 저장 -> 로그아웃 처리를 해주지 않으면 구글 계정 선택 팝업이 뜨지 않음

# 기능 구현 결과

https://user-images.githubusercontent.com/55148494/185466508-3798f028-538b-4241-863f-3c506a0193e6.mov

(구글 회원가입은 동영상 못 넣었습니다..)

# Resolve
- #39 
